### PR TITLE
Increase max number of reviews per PR.

### DIFF
--- a/src/clj/pullq/main.clj
+++ b/src/clj/pullq/main.clj
@@ -140,7 +140,8 @@
   (let [[opts _ banner] (get-cli args)
         config          (read-config (:path opts))
         env-token       (System/getenv "GITHUB_TOKEN")
-        auth            {:oauth-token (or (:token opts) env-token)}]
+        auth            {:oauth-token (or (:token opts) env-token)
+                         :per-page 100}]
     (when (:help opts)
       (println "Usage: pullq [-t token] [-f config] [-o outfile]\n")
       (print banner)


### PR DESCRIPTION
The default number of items fetched by tentacles is 30. We already hit
at least one case in production where the number of "reviews" (as
considered by github) was larger than that.

This change instead grabs the maximum allowed by github's API each time
(100 items).